### PR TITLE
Fix certificates section styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -398,6 +398,59 @@ span {
     list-style-type: disc;
 }
 
+.certificates {
+    min-height: auto;
+    padding-bottom: 10rem;
+}
+
+.certificates h2 {
+    margin-bottom: 5rem;
+}
+
+.certificates .certificates-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+}
+
+.certificates-container .certificates-box {
+    flex: 1 1 30rem;
+    background: var(--bg-color);
+    padding: 3rem 2rem 4rem;
+    border-radius: 2rem;
+    box-shadow: 0 .1rem .5rem var(--shadow-color);
+    text-align: center;
+    border-top: .6rem solid var(--main-color);
+    border-bottom: .6rem solid var(--main-color);
+    transition: .5s ease;
+}
+
+.certificates-container .certificates-box:hover {
+    box-shadow: 0 .1rem 2rem var(--shadow-color);
+    transform: scale(1.02);
+}
+
+.certificates-box i {
+    font-size: 7rem;
+    color: var(--main-color);
+}
+
+.certificates-box h3 {
+    font-size: 2.6rem;
+    transition: .5s ease;
+}
+
+.certificates-box:hover h3 {
+    color: var(--main-color);
+}
+
+.certificates-box p {
+    font-size: 1.6rem;
+    margin: 1rem 0 3rem;
+}
+
 .portfolio {
     min-height: auto;
     padding-bottom: 10rem;


### PR DESCRIPTION
## Summary
- reintroduce the certificates section styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688998baefec8333a4227bd257e6d1f0